### PR TITLE
Typo fix and consistent capitalization of "Discord" on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
 		            
 					<p>This is an unofficial Wiki for the game <a href="https://store.steampowered.com/app/2239150/Thronefall/">Thronefall</a>. 
 						Use the left sidebar to explore the wiki or to find a specific page.</p>
-					<p>Is anything missing or out of date? Don't hesitate to inform us about it on the <a href="https://discord.gg/gVYctptyg8">offical Thronefall Discord server</a> or the <a href="http://discord.gg/pfRJjfz6SU">wiki's disocrd server</a>!</p>
+					<p>Is anything missing or out of date? Don't hesitate to inform us about it on the <a href="https://discord.gg/gVYctptyg8">offical Thronefall Discord server</a> or the <a href="http://discord.gg/pfRJjfz6SU">wiki's Discord server</a>!</p>
   
 					<br>
 					<div id="gridWrapper">


### PR DESCRIPTION
The word "Discord" had a typo in it at the wiki discord link and was not capitalized while other occurences of the platform name were.