### PR TITLE
Spelling/grammatical error & readability fixes in eternal-trials.html

### DIFF
--- a/game-content/eternal-trials.html
+++ b/game-content/eternal-trials.html
@@ -58,7 +58,7 @@
 
         <h2 class="pageSubtitle" id="Gameplay"> Gameplay </h2>
         <hr>
-        <p>The eternal trials consists of stages. At the start of each stage the player is offered three options. Each option shows a map, a weapon and two perks. After the player has chosen an option, they will have to play on the selected map with their respective weapon and will optain the two chosen perks for the rest of their run. This means that the player has 2 perks on stage 1, 4 perks on stage 2, 6 perks on stage 3 and so on.</p>
+        <p>The eternal trials consists of stages. At the start of each stage the player is offered three options. Each option shows a map, a weapon and two perks. After the player has chosen an option, they will have to play on the selected map with their respective weapon and will obtain the two chosen perks for the rest of their run. This means that the player has 2 perks on stage 1, 4 perks on stage 2, 6 perks on stage 3 and so on.</p>
         <p>While the maps, weapons and perks are chosen by the player, they have to fight a randomised set of enemies each stage. The player has to face a random number of waves per map. The enemies in each of those waves are also randomly generated, meaning the player will face enemies that do not normally spawn on a specific map (see below for more details on wave generation).</p>
         <p>If the player manages to beat all the waves, they move on and are able to select the map, the weapon and the two perks for the next stage. The difficulty of the game increases with each stage (see below for more details on difficulty increases). After the players castle center eventually gets destroyed, they lose. All of their previous scores from each stage will be added together and the player receives a score bonus, increasing with each stage they have won. The stage bonus is calculated using this formular: <span class="codeBlock">(Won Stages)^2 x 10000</span>. After the player has received their final score, they lose all their perks and they may start another run.</p>
 
@@ -67,13 +67,21 @@
         <h2 class="pageSubtitle" id="Patterns"> Patterns </h2>
         <hr>
         <p>At the start of each stage, the wave generator uses a bunch of chances to determine which patterns the waves of the stage will have. Some possibilities are: Mono-battle stages, where you encounter the same one enemy type in every single wave (1.7%) and Mono-spawn stages, where enemies only spawn from one spawn point (10%).</p>
-        <p>Additionally, other parts of the stage are determined: 1. Starting economy (low, medium, high, extreme-high), 2. Spawn locations (random 1, random2, fixed 1, fixed 2,...), 3. Enemy types (random 1, random 2, fixed 1, fixed 2, siege, ...), 4. Wave durations, 5. Last wave bonus, 6. amount of <a href="../game-content/enemies/Elite_Enemies.html">elite enemies</a> (none, small part, medium part, large part) and many more.</p>
+        <p>Additionally, other parts of the stage are determined, such as:</p>
+		<ol>
+			<li>Starting economy (low, medium, high, extreme-high)</li>
+			<li>Spawn locations (random 1, random2, fixed 1, fixed 2,...)</li>
+			<li>Enemy types (random 1, random 2, fixed 1, fixed 2, siege, ...)</li>
+			<li>Wave durations</li>
+			<li>Last wave bonus</li>
+			<li>Amount of <a href="../game-content/enemies/Elite_Enemies.html">elite enemies</a> (none, small part, medium part, large part)</li>
+		</ol>
         <p>From stage 5 onwards the player always starts each stage with at least 11 gold.</p>
 
         <h2 class="pageSubtitle" id="DifficultyPoints"> Difficulty Points </h2>
         <hr>
         <p>The amount and power of enemies for each wave are determined by the amount of difficulty points. Difficulty points are a hidden statistic, purely in the background of the game.</p>
-        <p>The amount of difficulty points per wave is determined by a complex calculation in the background of the game. It considers the current stage (the first 7 stages the difficulty increases exponential, after that linear), spawn location proximity to castle center (single multiplier), wave length (exponential) and simulated economy (this includes and is dependant on starting gold).</p>
+        <p>The amount of difficulty points per wave is determined by a complex calculation in the background of the game. It considers the current stage (the first 7 stages the difficulty increases exponentially, after that linearly), spawn location proximity to castle center (single multiplier), wave length (exponential) and simulated economy (this includes and is dependent on starting gold).</p>
         <p>When creating waves, the game spends the difficulty points to spawn enemies. For example 18 per <a href="../game-content/enemies/exploder.html">exploder</a>.</p>
 
                 <table>


### PR DESCRIPTION
Fixed some spelling and grammatical errors and made the list under the "Patterns" header a bit easier to read. (may just be me but I found the inline numbering a tad confusing to read through)