### PR TITLE
Spelling & capitalization fixes for the about wiki page

### DIFF
--- a/about/wiki.html
+++ b/about/wiki.html
@@ -73,7 +73,7 @@
 					</tr>
 					<tr>
 						<td><strong>ItsMe_Raven</strong></td>
-						<td>Aarticle writing and design</td>
+						<td>Article writing and design</td>
 					</tr>
 					<tr>
 						<td><strong>lich46, Gertimoshka</strong></td>
@@ -86,11 +86,11 @@
 					</tr> -->
 					<tr>
 						<td><strong>FlediX2</strong></td>
-						<td>information feedback</td>
+						<td>Information feedback</td>
 					</tr>
 					<tr>
 						<td><strong>LTU_Adas</strong></td>
-						<td>information and design deedback</td>
+						<td>Information and design feedback</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
Fixed a few missing capitalizations and spelling errors